### PR TITLE
FROM "bugfix/disable-click-outside-modal" TO "development"

### DIFF
--- a/src/components/modals/EventModal.js
+++ b/src/components/modals/EventModal.js
@@ -39,6 +39,7 @@ export default function EventModal() {
         <FaCalendarPlus />
       </Button>
       <Dialog 
+        disableBackdropClick 
         open={open} 
         onClose={handleClose}
         fullWidth={true}


### PR DESCRIPTION
Event modal won't close unless press cancel